### PR TITLE
Remove invalid reference links from keywords.txt

### DIFF
--- a/I2C_ADC/keywords.txt
+++ b/I2C_ADC/keywords.txt
@@ -6,8 +6,8 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-ADC2	KEYWORD1	ADC2
-I2C_ADC	KEYWORD1	I2C_ADC
+ADC2	KEYWORD1
+I2C_ADC	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)

--- a/I2C_DigitalPot/keywords.txt
+++ b/I2C_DigitalPot/keywords.txt
@@ -6,8 +6,8 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-D_POT	KEYWORD1	D_POT
-I2C_DigitalPot	KEYWORD1	I2C_DigitalPot
+D_POT	KEYWORD1
+I2C_DigitalPot	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)

--- a/I2C_EEPROM/keywords.txt
+++ b/I2C_EEPROM/keywords.txt
@@ -6,8 +6,8 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-EEPROM2	KEYWORD1	EEPROM2
-I2C_EEPROM	KEYWORD1	I2C_EEPROM
+EEPROM2	KEYWORD1
+I2C_EEPROM	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)

--- a/I2C_PortExpander/keywords.txt
+++ b/I2C_PortExpander/keywords.txt
@@ -6,9 +6,9 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-portExpander	KEYWORD1	portExpander
-I2C_PORTEXPANDER	KEYWORD1	I2C_PORTEXPANDER
-I2C_PortExpander	KEYWORD1	I2C_PortExpander
+portExpander	KEYWORD1
+I2C_PORTEXPANDER	KEYWORD1
+I2C_PortExpander	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The third field of keywords.txt is used to provide Arduino Language Reference links, which are accessed from the Arduino IDE by highlighting the keyword and then selecting "Find in Reference" from the Help or right click menu. Adding values to this field that do not match any existing reference pages results in a "Could not open the URL" error.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywordstxt-format